### PR TITLE
Fix: Escape date/time separators

### DIFF
--- a/src/Twilio/Converters/Serializers.cs
+++ b/src/Twilio/Converters/Serializers.cs
@@ -29,7 +29,7 @@ namespace Twilio.Converters
         {
             if (input == null) return null;
 
-            return input.Value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            return input.Value.ToString("yyyy'-'MM'-'ddTHH':'mm':'ssZ");
         }
 
         public static string Url(Uri input) 

--- a/src/Twilio/Converters/Serializers.cs
+++ b/src/Twilio/Converters/Serializers.cs
@@ -28,7 +28,8 @@ namespace Twilio.Converters
         public static string DateTimeIso8601(DateTime? input)
         {
             if (input == null) return null;
-
+            
+            // Explicitly escape separators to avoid using system/culture defaults.
             return input.Value.ToString("yyyy'-'MM'-'ddTHH':'mm':'ssZ");
         }
 


### PR DESCRIPTION


<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
Escape date and time separators to avoid using system/culture defaults, as defaults are not - for dates and : for time in all cultures.
# Fixes #
#596

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - passing existing date serialization test should be sufficient
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
  - This should not be a breaking change - but has the chance to be if people have written very stupid code to change the produced request object instead of changing cultures.
- [x] I have added inline documentation to the code I modified


